### PR TITLE
update sshfs.sock path to /run/docker/plugins

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	sshfsId       = "_sshfs"
-	socketAddress = "/usr/share/docker/plugins/sshfs.sock"
+	socketAddress = "/run/docker/plugins/sshfs.sock"
 )
 
 var (


### PR DESCRIPTION
Per https://docs.docker.com/engine/extend/plugin_api/#plugin-discovery : 

> UNIX domain socket files must be located under /run/docker/plugins

I believe this change occurred in 1.8 or 1.9, can't find exactly when that happened...