### PR TITLE
Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+go:
+  - 1.4.2
+sudo: false
+env:
+  - "PATH=/home/travis/gopath/bin:$PATH"
+script:
+  - GOOS=linux GOARCH=amd64 go build -v
+deploy:
+  provider: releases
+  api_key: "${GITHUB_TOKEN:?}"
+  file: "docker-volume-sshfs"
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
@vieux, it would be wonderful with an official release so I took the liberty of automating the process by adding a build file, `.travis.yml`. Travis CI will build the code on every commit and deploy the binary to the GitHub repository's release page for every tagged commit.

What's left is that you create a [Travis CI account](http://travis-ci.org/), a [GitHub token](https://github.com/settings/tokens/new), and add a `GITHUB_TOKEN` environmental variable in Travis CI for this repository.
