### PR TITLE
Add support for SSH keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,70 @@ This plugin allows you to mount remote folder using sshfs in your container easi
 
 ## Usage
 
+### Use with SSH keys
 1 - Install the plugin
 
 ```
 $ docker plugin install vieux/sshfs # or docker plugin install vieux/sshfs DEBUG=1
+Plugin "vieux/sshfs" is requesting the following privileges:
+ - network: [host]
+ - mount: [/tmp]
+ - device: [/dev/fuse]
+ - capabilities: [CAP_SYS_ADMIN]
+Do you grant the above permissions? [y/N] y
+latest: Pulling from vieux/sshfs
+e248a6530152: Download complete
+Status: Downloaded newer image for vieux/sshfs:latest
+Installed plugin vieux/sshfs
+```
+
+2 - Configure driver to point to your SSH keys
+
+_NOTE_: The plugin defaults to looking for SSH keys in `/tmp`. You can copy your `<identity_file_name>` to `/tmp` and omit this step, e.g.
+`cp $HOME/.ssh/id_rsa /tmp/.`
+
+```
+$ docker plugin disable vieux/sshfs
+vieux/sshfs
+
+$ docker plugin set vieux/sshfs KeyPath.source=$HOME/.ssh
+
+$ docker plugin enable vieux/sshfs
+vieux/sshfs
+```
+3 - Create a volume
+
+```
+$ docker volume create -d vieux/sshfs -o sshcmd=<user@host:path> -o identity=<identity_file_name> sshvolume
+sshvolume
+
+$ docker volume ls
+DRIVER              VOLUME NAME
+vieux/sshfs         sshvolume
+```
+
+4 - Use the volume
+
+```
+$ docker run --rm -it -v sshvolume:<path> busybox ls <path>
+```
+
+### Alternatively, use with passwords instead of SSH keys
+1 - Install the plugin
+
+```
+$ docker plugin install vieux/sshfs # or docker plugin install vieux/sshfs DEBUG=1
+Plugin "vieux/sshfs" is requesting the following privileges:
+ - network: [host]
+ - mount: [/tmp]
+ - device: [/dev/fuse]
+ - capabilities: [CAP_SYS_ADMIN]
+Do you grant the above permissions? [y/N] y
+latest: Pulling from vieux/sshfs
+e248a6530152: Download complete
+Status: Downloaded newer image for vieux/sshfs:latest
+Installed plugin vieux/sshfs
+
 ```
 
 2 - Create a volume
@@ -17,21 +77,31 @@ $ docker plugin install vieux/sshfs # or docker plugin install vieux/sshfs DEBUG
 ```
 $ docker volume create -d vieux/sshfs -o sshcmd=<user@host:path> -o password=<password> sshvolume
 sshvolume
+
 $ docker volume ls
 DRIVER              VOLUME NAME
-local               2d75de358a70ba469ac968ee852efd4234b9118b7722ee26a1c5a90dcaea6751
-local               842a765a9bb11e234642c933b3dfc702dee32b73e0cf7305239436a145b89017
-local               9d72c664cbd20512d4e3d5bb9b39ed11e4a632c386447461d48ed84731e44034
-local               be9632386a2d396d438c9707e261f86fd9f5e72a7319417901d84041c8f14a4d
-local               e1496dfe4fa27b39121e4383d1b16a0a7510f0de89f05b336aab3c0deb4dda0e
 vieux/sshfs         sshvolume
 ```
 
 3 - Use the volume
 
 ```
-$ docker run -it -v sshvolume:<path> busybox ls <path>
+$ docker run --rm -it -v sshvolume:<path> busybox ls <path>
 ```
+
+### Removing the plugin
+_NOTE_: You must remove any volumes created with this plugin prior to removing the plugin itself.
+
+```
+$ docker plugin disable vieux/sshfs
+vieux/sshfs
+
+$ docker plugin rm vieux/sshfs
+vieux/sshfs
+```
+
+## Notes
+* When using the SSH key approach, the directory where the keys are located must be on the same host as the docker engine.
 
 ## THANKS
 

--- a/config.json
+++ b/config.json
@@ -18,6 +18,17 @@
 	    ]
 	},
 	"propagatedmount": "/mnt",
+	"mounts": [
+		{
+		"name": "KeyPath",
+		"description": "Path to SSH keys",
+		"source": "/tmp",
+		"destination": "/tmp/sshfs",
+		"type": "bind",
+		"options": ["rbind","ro"],
+		"settable":["source"]
+		}
+	],
 	"env": [
 	    {
 		"name":"DEBUG",


### PR DESCRIPTION
* New `-o identity <filename>` command argument for `docker volume create`
* Add "mounts" section to config.json
* Update README

Signed-off-by: David Williamson <david.williamson@docker.com>

### Testing
* Tested with SSH keys to remote host on AWS
* Tested with passwords to remote host on docker LAN
* negative test, trying to use both key and password
* Tests run on:
  * OSX 10.12.2 (Sierra); docker4Mac Version 1.13.0-rc6-beta36
  * Ubuntu 16.04; docker version 1.13.0-rc4
* Commands testing
  * `docker plugin install`
  * `docker plugin inspect`
  * `docker plugin ls`
  * `docker plugin disable`
  * `docker plugin set`
  * `docker plugin enable`
  * `docker plugin rm`

* A build of the plugin for this PR is available on hub at `davidw135/sshfs` if reviewers want to test for themselves. `docker plugin install davidw135/sshfs`

cc/ @cyli 