### PR TITLE
Add sshfs command stderr output into err message

### DIFF
--- a/main.go
+++ b/main.go
@@ -252,7 +252,11 @@ func (d *sshfsDriver) mountVolume(v *sshfsVolume) error {
 	}
 
 	logrus.Debug(cmd.Args)
-	return cmd.Run()
+	output,err := cmd.CombinedOutput()
+	if err != nil {
+		return logError("sshfs command execute failed: %s ( %s )", err, string(output))
+	}
+	return nil
 }
 
 func (d *sshfsDriver) unmountVolume(target string) error {


### PR DESCRIPTION
It should be better to output the command's full output instead of an exit code -1.