### PR TITLE
considering port when generating mount point

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func (d *sshfsDriver) Create(r *volume.CreateRequest) error {
 	if v.Sshcmd == "" {
 		return logError("'sshcmd' option required")
 	}
-	v.Mountpoint = filepath.Join(d.root, fmt.Sprintf("%x", md5.Sum(append([]byte(v.Sshcmd),[]byte(v.Port)...)))
+	v.Mountpoint = filepath.Join(d.root, fmt.Sprintf("%x", md5.Sum(append([]byte(v.Sshcmd),[]byte(v.Port)...))))
 
 	d.volumes[r.Name] = v
 

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func (d *sshfsDriver) Create(r *volume.CreateRequest) error {
 	if v.Sshcmd == "" {
 		return logError("'sshcmd' option required")
 	}
-	v.Mountpoint = filepath.Join(d.root, fmt.Sprintf("%x", md5.Sum(append([]byte(v.Sshcmd, ),[]byte(v.Port)...)))
+	v.Mountpoint = filepath.Join(d.root, fmt.Sprintf("%x", md5.Sum(append([]byte(v.Sshcmd),[]byte(v.Port)...)))
 
 	d.volumes[r.Name] = v
 

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func (d *sshfsDriver) Create(r *volume.CreateRequest) error {
 	if v.Sshcmd == "" {
 		return logError("'sshcmd' option required")
 	}
-	v.Mountpoint = filepath.Join(d.root, fmt.Sprintf("%x", md5.Sum([]byte(v.Sshcmd))))
+	v.Mountpoint = filepath.Join(d.root, fmt.Sprintf("%x", md5.Sum(append([]byte(v.Sshcmd, ),[]byte(v.Port)...)))
 
 	d.volumes[r.Name] = v
 


### PR DESCRIPTION
This simple change should enable differentiating two container running on the same host, sharing user name etc. but only differ in the exposed port.

Solving #59 