### PR TITLE
Added new 'sshauthsock' option

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,6 +43,15 @@
       "type": "bind"
     },
     {
+      "destination": "/tmp",
+      "options": [
+        "rbind"
+      ],
+      "name": "tmp",
+      "source": "/tmp/",
+      "type": "bind"
+    },
+    {
       "destination": "/root/.ssh",
       "options": [
         "rbind"

--- a/main.go
+++ b/main.go
@@ -20,9 +20,10 @@ import (
 const socketAddress = "/run/docker/plugins/sshfs.sock"
 
 type sshfsVolume struct {
-	Password string
-	Sshcmd   string
-	Port     string
+	Password    string
+	Sshcmd      string
+	Port        string
+	SSHAuthSock string
 
 	Options []string
 
@@ -90,6 +91,8 @@ func (d *sshfsDriver) Create(r *volume.CreateRequest) error {
 			v.Password = val
 		case "port":
 			v.Port = val
+		case "sshauthsock":
+			v.SSHAuthSock = val
 		default:
 			if val != "" {
 				v.Options = append(v.Options, key+"="+val)
@@ -245,6 +248,9 @@ func (d *sshfsDriver) mountVolume(v *sshfsVolume) error {
 	if v.Password != "" {
 		cmd.Args = append(cmd.Args, "-o", "workaround=rename", "-o", "password_stdin")
 		cmd.Stdin = strings.NewReader(v.Password)
+	}
+	if v.SSHAuthSock != "" {
+		cmd.Env = append(cmd.Env, "SSH_AUTH_SOCK="+v.SSHAuthSock)
 	}
 
 	for _, option := range v.Options {


### PR DESCRIPTION
This patch allows me to authenticate without password:
```
docker volume create -d h0tbird/sshfs:next -o sshcmd=${RUSER}@localhost:${RMOUNT} -o port=2222 -o workaround=rename -o sshauthsock=${SSH_AUTH_SOCK} data-${RUSER}
```