### PR TITLE
Use tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN set -ex \
 CMD ["/go/bin/docker-volume-sshfs"]
 
 FROM alpine
-RUN apk update && apk add sshfs
+RUN apk update && apk add sshfs && apk add --no-cache tini
 RUN mkdir -p /run/docker/plugins /mnt/state /mnt/volumes
 COPY --from=builder /go/bin/docker-volume-sshfs .
 CMD ["docker-volume-sshfs"]

--- a/config.json
+++ b/config.json
@@ -2,6 +2,8 @@
   "description": "sshFS plugin for Docker",
   "documentation": "https://docs.docker.com/engine/extend/plugins/",
   "entrypoint": [
+    "/sbin/tini",
+    "--",
     "/docker-volume-sshfs"
   ],
   "env": [


### PR DESCRIPTION
Use tini to avoid leaving zombie processes when a docker container with docker-volume-sshfs plugin is stopped. Fixes #78 

This patch is adopted from https://github.com/trajano/docker-volume-plugins/pull/30